### PR TITLE
Update  svc-invoke-dapr-nodejs README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,7 @@ Deploy to Azure for dev-test
 
 > NOTE: make sure you have Azure Dev CLI pre-reqs [here](https://github.com/Azure-Samples/todo-python-mongo-aca)
 
-1. Open a terminal, create a new empty folder, and change into it.
-2. Run the following command to initialize the project. 
+1. Run the following command to initialize the project. 
 
 ```bash
 azd init --template https://github.com/Azure-Samples/svc-invoke-dapr-nodejs
@@ -73,7 +72,7 @@ This command will clone the code to your current folder and prompt you for the f
 
 - `Environment Name`: This will be used as a prefix for the resource group that will be created to hold all Azure resources. This name should be unique within your Azure subscription.
 
-3. Run the following command to build a deployable copy of your application, provision the template's infrastructure to Azure and also deploy the applciation code to those newly provisioned resources.
+2. Run the following command to build a deployable copy of your application, provision the template's infrastructure to Azure and also deploy the applciation code to those newly provisioned resources.
 
 ```bash
 azd up
@@ -85,7 +84,7 @@ This command will prompt you for the following information:
 
 > NOTE: This may take a while to complete as it executes three commands: `azd package` (builds a deployable copy of your application),`azd provision` (provisions Azure resources), and `azd deploy` (deploys application code). You will see a progress indicator as it packages, provisions and deploys your application.
 
-4. Confirm the deployment is susccessful:
+3. Confirm the deployment is susccessful:
 
 Navigate to the Container App resources for both the Checkout and Order-Processor services. Locate the `Log stream` and confirm the app container is logging each request successfully. 
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ This command will clone the code to your current folder and prompt you for the f
 
 - `Environment Name`: This will be used as a prefix for the resource group that will be created to hold all Azure resources. This name should be unique within your Azure subscription.
 
-2. Run the following command to build a deployable copy of your application, provision the template's infrastructure to Azure and also deploy the applciation code to those newly provisioned resources.
+2. Run the following command to package a deployable copy of your application, provision the template's infrastructure to Azure and also deploy the application code to those newly provisioned resources.
 
 ```bash
 azd up
@@ -82,7 +82,7 @@ This command will prompt you for the following information:
 - `Azure Location`: The Azure location where your resources will be deployed.
 - `Azure Subscription`: The Azure Subscription where your resources will be deployed.
 
-> NOTE: This may take a while to complete as it executes three commands: `azd package` (builds a deployable copy of your application),`azd provision` (provisions Azure resources), and `azd deploy` (deploys application code). You will see a progress indicator as it packages, provisions and deploys your application.
+> NOTE: This may take a while to complete as it executes three commands: `azd package` (packages a deployable copy of your application),`azd provision` (provisions Azure resources), and `azd deploy` (deploys application code). You will see a progress indicator as it packages, provisions and deploys your application.
 
 3. Confirm the deployment is susccessful:
 

--- a/README.md
+++ b/README.md
@@ -62,12 +62,30 @@ Deploy to Azure for dev-test
 
 > NOTE: make sure you have Azure Dev CLI pre-reqs [here](https://github.com/Azure-Samples/todo-python-mongo-aca)
 
-1. Provision infra and deploy application:
+1. Open a terminal, create a new empty folder, and change into it.
+2. Run the following command to initialize the project. 
+
+```bash
+azd init --template https://github.com/Azure-Samples/svc-invoke-dapr-nodejs
+``` 
+
+This command will clone the code to your current folder and prompt you for the following information:
+
+- `Environment Name`: This will be used as a prefix for the resource group that will be created to hold all Azure resources. This name should be unique within your Azure subscription.
+
+3. Run the following command to build a deployable copy of your application, provision the template's infrastructure to Azure and also deploy the applciation code to those newly provisioned resources.
+
 ```bash
 azd up
 ```
 
-2. Confirm the deployment is susccessful:
+This command will prompt you for the following information:
+- `Azure Location`: The Azure location where your resources will be deployed.
+- `Azure Subscription`: The Azure Subscription where your resources will be deployed.
+
+> NOTE: This may take a while to complete as it executes three commands: `azd package` (builds a deployable copy of your application),`azd provision` (provisions Azure resources), and `azd deploy` (deploys application code). You will see a progress indicator as it packages, provisions and deploys your application.
+
+4. Confirm the deployment is susccessful:
 
 Navigate to the Container App resources for both the Checkout and Order-Processor services. Locate the `Log stream` and confirm the app container is logging each request successfully. 
 


### PR DESCRIPTION
Update svc-invoke-dapr-nodejs README to use `azd init` and `azd up` instead of `azd up --template` according to https://github.com/Azure/azure-dev/issues/1769.

@jongio, @rajeshkamal5050 for notification.